### PR TITLE
Fix bug with cleanupSync wrongfully executed

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function cleanupSync (er) {
 // When we *would* emit 'close' or 'finish', instead do our stuff
 WriteStream.prototype.emit = function (ev) {
   if (ev === 'error')
-    return cleanupSync(this)
+    return cleanupSync.call(this, arguments[1])
 
   if (ev !== 'close' && ev !== 'finish')
     return fs.WriteStream.prototype.emit.apply(this, arguments)


### PR DESCRIPTION
If you try to manually emit an error on the writeStream it will output the following:

```
events.js:74
        throw TypeError('Uncaught, unspecified "error" event.');
```

That happens because instead of an error being emitted it's the steam itself.