### PR TITLE
deps: Upgrade graceful-fs dependency to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "graceful-fs": "^3.0.2"
+    "graceful-fs": "^4.1.2"
   },
   "devDependencies": {
     "tap": "^1.2.0"


### PR DESCRIPTION
graceful-fs used to monkey-patch node's core fs module.
This has been fixed in the version 4.

Related: https://github.com/nodejs/node/pull/2714