### PR TITLE
User murmur instead of md5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 4.1

--- a/index.js
+++ b/index.js
@@ -1,18 +1,18 @@
 var fs = require('graceful-fs')
 var util = require('util')
-var crypto = require('crypto')
+var MurmurHash3 = require('imurmurhash');
 
-function md5hex () {
-  var hash = crypto.createHash('md5')
+function murmurhex () {
+  var hash = MurmurHash3('');
   for (var ii=0; ii<arguments.length; ++ii) {
-    hash.update(''+arguments[ii])
+    hash.hash(hash+arguments[ii]);
   }
-  return hash.digest('hex')
+  return hash.result();
 }
 
 var invocations = 0;
 function getTmpname (filename) {
-  return filename + "." + md5hex(__filename, process.pid, ++invocations)
+  return filename + "." + murmurhex(__filename, process.pid, ++invocations)
 }
 
 module.exports = WriteStream

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "test": "test"
   },
   "dependencies": {
-    "graceful-fs": "^4.1.2"
+    "graceful-fs": "^4.1.2",
+    "imurmurhash": "^0.1.4"
   },
   "devDependencies": {
     "tap": "^1.2.0"


### PR DESCRIPTION
MD5 is disallowed in FIPS mode, use a pure JS version of murmur instead.

Resolves https://github.com/npm/fs-write-stream-atomic/issues/5