### PR TITLE
Rewrite to to using a PassThrough stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   },
   "dependencies": {
     "graceful-fs": "^4.1.2",
-    "imurmurhash": "^0.1.4"
+    "iferr": "^0.1.5",
+    "imurmurhash": "^0.1.4",
+    "readable-stream": "1 || 2"
   },
   "devDependencies": {
     "standard": "^5.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "readable-stream": "1 || 2"
   },
   "devDependencies": {
+    "rimraf": "^2.4.4",
     "standard": "^5.4.1",
     "tap": "^2.3.1"
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -10,40 +10,39 @@ test('basic', function (t) {
   var target = path.resolve(__dirname, 'test.txt')
   var n = 10
 
+  // We run all of our assertions twice:
+  //   once for finish, once for close
+  // There are 6 assertions, two fixed, plus 4 lines in the file.
+  t.plan(n * 2 * 6)
+
   var streams = []
   for (var i = 0; i < n; i++) {
     var s = writeStream(target)
-    s.on('finish', verifier('finish'))
-    s.on('close', verifier('close'))
+    s.on('finish', verifier('finish', i))
+    s.on('close', verifier('close', i))
     streams.push(s)
   }
 
-  var verifierCalled = 0
-  function verifier (ev) {
+  function verifier (ev, num) {
     return function () {
       if (ev === 'close') {
-        t.equal(this.__emittedFinish, true)
+        t.equal(this.__emittedFinish, true, num + '. closed only after finish')
       } else {
         this.__emittedFinish = true
-        t.equal(ev, 'finish')
+        t.equal(ev, 'finish', num + '. finished')
       }
 
       // make sure that one of the atomic streams won.
       var res = fs.readFileSync(target, 'utf8')
       var lines = res.trim().split(/\n/)
-      lines.forEach(function (line) {
+      lines.forEach(function (line, lineno) {
         var first = lines[0].match(/\d+$/)[0]
         var cur = line.match(/\d+$/)[0]
-        t.equal(cur, first)
+        t.equal(cur, first, num + '. line ' + lineno + ' matches')
       })
 
       var resExpr = /^first write \d+\nsecond write \d+\nthird write \d+\nfinal write \d+\n$/
-      t.similar(res, resExpr)
-
-      // should be called once for each close, and each finish
-      if (++verifierCalled === n * 2) {
-        t.end()
-      }
+      t.similar(res, resExpr, num + '. content matches')
     }
   }
 

--- a/test/chown.js
+++ b/test/chown.js
@@ -20,19 +20,6 @@ test('chown works', function (t) {
   stream.end()
 })
 
-test('chown fails', function (t) {
-  t.plan(1)
-  if (process.getuid() === 0) {
-    t.pass("# SKIP - Can't test chown failures as root")
-    return
-  }
-  var stream = writeStream(target, {chown: {uid: 0, gid: 0}})
-  stream.on('error', function (er) {
-    t.ok(er, 'got chown error before close')
-  })
-  stream.end()
-})
-
 test('cleanup', function (t) {
   rimraf.sync(target)
   t.end()

--- a/test/chown.js
+++ b/test/chown.js
@@ -1,0 +1,39 @@
+'use strict'
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var writeStream = require('../index.js')
+
+var target = path.resolve(__dirname, 'test-chown')
+
+test('chown works', function (t) {
+  t.plan(1)
+  var stream = writeStream(target, {chown: {uid: process.getuid(), gid: process.getgid()}})
+  var hadError = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.error('#', er)
+  })
+  stream.on('close', function () {
+    t.is(hadError, false, 'no errors before close')
+  })
+  stream.end()
+})
+
+test('chown fails', function (t) {
+  t.plan(1)
+  if (process.getuid() === 0) {
+    t.pass("# SKIP - Can't test chown failures as root")
+    return
+  }
+  var stream = writeStream(target, {chown: {uid: 0, gid: 0}})
+  stream.on('error', function (er) {
+    t.ok(er, 'got chown error before close')
+  })
+  stream.end()
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(target)
+  t.end()
+})

--- a/test/toolong.js
+++ b/test/toolong.js
@@ -13,12 +13,7 @@ function repeat (times, string) {
 var target = path.resolve(__dirname, repeat(1000, 'test'))
 
 test('name too long', function (t) {
-  // 0.8 streams smh
-  if (process.version.indexOf('v0.8') !== -1) {
-    t.plan(1)
-  } else {
-    t.plan(2)
-  }
+  t.plan(2)
   var stream = writeStream(target)
   var hadError = false
   stream.on('error', function (er) {


### PR DESCRIPTION
For better 0.8 compatibility, use ReadableStream to get modern streams and rebuild this as a PassThrough stream that just hooks `_flush` and doesn't do anything weird with event emitters.