### PR TITLE
Rewrite as writable

### DIFF
--- a/test/chown.js
+++ b/test/chown.js
@@ -1,4 +1,5 @@
 'use strict'
+var fs = require('graceful-fs')
 var path = require('path')
 var test = require('tap').test
 var rimraf = require('rimraf')
@@ -12,10 +13,27 @@ test('chown works', function (t) {
   var hadError = false
   stream.on('error', function (er) {
     hadError = true
-    console.error('#', er)
+    console.log('#', er)
   })
   stream.on('close', function () {
     t.is(hadError, false, 'no errors before close')
+  })
+  stream.end()
+})
+
+test('chown fails', function (t) {
+  t.plan(1)
+  fs.chown = function (file, uid, gid, cb) {
+    cb(new Error('TEST BREAK'))
+  }
+  var stream = writeStream(target, {chown: {uid: process.getuid(), gid: process.getgid()}})
+  var hadError = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.log('#', er)
+  })
+  stream.on('close', function () {
+    t.is(hadError, true, 'error before close')
   })
   stream.end()
 })

--- a/test/rename-fail.js
+++ b/test/rename-fail.js
@@ -1,0 +1,30 @@
+'use strict'
+var fs = require('graceful-fs')
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var writeStream = require('../index.js')
+
+var target = path.resolve(__dirname, 'test-rename')
+
+test('rename fails', function (t) {
+  t.plan(1)
+  fs.rename = function (src, dest, cb) {
+    cb(new Error('TEST BREAK'))
+  }
+  var stream = writeStream(target)
+  var hadError = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.log('#', er)
+  })
+  stream.on('close', function () {
+    t.is(hadError, true, 'error before close')
+  })
+  stream.end()
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(target)
+  t.end()
+})

--- a/test/slow-close.js
+++ b/test/slow-close.js
@@ -1,0 +1,40 @@
+'use strict'
+var fs = require('graceful-fs')
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var writeStream = require('../index.js')
+
+var target = path.resolve(__dirname, 'test-chown')
+
+test('slow close', function (t) {
+  t.plan(2)
+  // The goal here is to simulate the "file close" step happening so slowly
+  // that the whole close/rename process could finish before the file is
+  // actually closed (and thus buffers truely flushed to the OS). In
+  // previous versions of this module, this would result in the module
+  // emitting finish & close before the file was fully written and in
+  // turn, could break other layers that tried to read the new file.
+  var realEmit = fs.WriteStream.prototype.emit
+  var reallyClosed = false
+  fs.WriteStream.prototype.emit = function (event) {
+    if (event !== 'close') return realEmit.apply(this, arguments)
+    setTimeout(function () {
+      reallyClosed = true
+      realEmit.call(this, 'close')
+    }.bind(this), 200)
+  }
+  var stream = writeStream(target)
+  stream.on('finish', function () {
+    t.is(reallyClosed, true, "didn't finish before target was closed")
+  })
+  stream.on('close', function () {
+    t.is(reallyClosed, true, "didn't close before target was closed")
+  })
+  stream.end()
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(target)
+  t.end()
+})


### PR DESCRIPTION
The PassThrough implementation introduced a race condition on 0.12+, where we would complete processing and emit `finish` before the underlying file stream had flushed all of its buffers to disk. Since the thing we do immediately after writing w/ the remote tarball handler is read the file, it found an incomplete file.

This corrects that by rewriting the as a writable proxy and introducing more test cases.

The original problem that started these rewrites was ultimately a bug in the node 0.8 http streams, and our work around for that in npm works as well with this version of the module as the original 1.0.5, so our alternatives right now are merging this and releasing 1.0.8 or reverting to 1.0.5 (and maybe bringing the new tests back).