### PR TITLE
Handle EPERM errors when renaming files on windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (/^win/).test(process.platform)
+  this.__isWin = (options && options.isWin) || (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = options && options.hasOwnProperty('isWin') ? options.isWin : (/^win/).test(process.platform)
+  this.__isWin = options && options.hasOwnProperty('isWin') ? options.isWin : process.platform === 'win32'
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (/^win/).test(process.platform);
+  this.__isWin = (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)
@@ -92,7 +92,7 @@ function handleClose (writeStream) {
       writeStream.emit('close')
     })
   }
-  function trapWindowsEPERMRename(err) {
+  function trapWindowsEPERMRename (err) {
     if (err.syscall && err.syscall === 'rename' &&
         err.code && err.code === 'EPERM' &&
         writeStream.__isWin
@@ -101,11 +101,11 @@ function handleClose (writeStream) {
       // if the target file exists, we can ignore the EPERM error
       if (fs.existsSync(writeStream.__atomicTarget)) {
         // a little janky, call end() directly
-        return end();
+        return end()
       }
     }
 
-    cleanup(err);
+    cleanup(err)
   }
   function moveIntoPlace () {
     fs.rename(writeStream.__atomicTmp, writeStream.__atomicTarget, iferr(trapWindowsEPERMRename, end))

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (options && options.isWin) || (/^win/).test(process.platform)
+  this.__isWin = options && options.hasOwnProperty('isWin') ? options.isWin : (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)

--- a/test/rename-eperm.js
+++ b/test/rename-eperm.js
@@ -1,0 +1,49 @@
+'use strict'
+var fs = require('graceful-fs')
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var writeStream = require('../index.js')
+
+var target = path.resolve(__dirname, 'test-rename-eperm')
+
+test('rename eperm', function (t) {
+  t.plan(2)
+
+  var _rename = fs.rename
+  fs.existsSync = function (src) {
+    return true
+  }
+  fs.rename = function (src, dest, cb) {
+    // simulate a failure during rename where the file
+    // is renamed successfully but the process encounters
+    // an EPERM error
+    _rename(src, dest, function (e) {
+      var err = new Error('TEST BREAK')
+      err.syscall = 'rename'
+      err.code = 'EPERM'
+      cb(err)
+    })
+  }
+
+  var stream = writeStream(target, { isWin: true })
+  var hadError = false
+  var calledFinish = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.log('#', er)
+  })
+  stream.on('finish', function () {
+    calledFinish = true
+  })
+  stream.on('close', function () {
+    t.is(hadError, false, 'error was caught')
+    t.is(calledFinish, true, 'finish was called before close')
+  })
+  stream.end()
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(target)
+  t.end()
+})


### PR DESCRIPTION
This came from the discussion in npm/npm#12333. When running `npm install` in our CI system very often we'll see EPERM errors at the point when npm tries to populate tarballs into its cache. When we check the cache directory the tarball does exist and is valid.

This PR updates fs-write-stream-atomic to not throw EPERM errors on rename if the platform is windows and the target file exists.