### PR TITLE
Handle eperm errors windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,12 @@ function handleClose (writeStream) {
                 targetHash.update(targeBuffer)
 
                 if (tmpHash.digest('hex') === targetHash.digest('hex')) {
-                  // a little janky, call end() directly
-                  return end()
+                  try {
+                    fs.unlinkSync(writeStream.__atomicTmp)
+                  } finally {
+                    // a little janky, call end() directly
+                    return end()
+                  }
                 }
 
                 return cleanup(err)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (/^win/).test(process.platform)
+  this.__isWin = (options && options.isWin) || (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = options && options.hasOwnProperty('isWin') ? options.isWin : (/^win/).test(process.platform)
+  this.__isWin = options && options.hasOwnProperty('isWin') ? options.isWin : process.platform === 'win32'
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var Writable = require('readable-stream').Writable
 var util = require('util')
 var MurmurHash3 = require('imurmurhash')
 var iferr = require('iferr')
-var md5 = require('md5')
+var crypto = require('crypto')
 
 function murmurhex () {
   var hash = MurmurHash3('')
@@ -99,18 +99,21 @@ function handleClose (writeStream) {
         writeStream.__isWin
     ) {
       if (fs.existsSync(writeStream.__atomicTarget)) {
+        var tmpHash = crypto.createHash('sha256')
+        var targetHash = crypto.createHash('sha256')
+
         fs.readFile(writeStream.__atomicTmp,
           function (readTmpErr, tmpBuffer) {
             if (readTmpErr) return cleanup(err)
 
-            var tmpMD5 = md5(tmpBuffer)
+            tmpHash.update(tmpBuffer)
             fs.readFile(writeStream.__atomicTarget,
               function (readTargetErr, targeBuffer) {
                 if (readTargetErr) return cleanup(err)
 
-                var targetMD5 = md5(targeBuffer)
+                targetHash.update(targeBuffer)
 
-                if (tmpMD5 === targetMD5) {
+                if (tmpHash.digest('hex') === targetHash.digest('hex')) {
                   // a little janky, call end() directly
                   return end()
                 }

--- a/index.js
+++ b/index.js
@@ -100,18 +100,18 @@ function handleClose (writeStream) {
     ) {
       if (fs.existsSync(writeStream.__atomicTarget)) {
         fs.readFile(writeStream.__atomicTmp,
-          function (readErr, buf) {
-            if (readErr) return cleanup(err)
+          function (readTmpErr, tmpBuffer) {
+            if (readTmpErr) return cleanup(err)
 
-            var atomicTmpMD5 = md5(buf)
+            var tmpMD5 = md5(tmpBuffer)
             fs.readFile(writeStream.__atomicTarget,
-              function (readErr, buf) {
-                if (readErr) return cleanup(err)
+              function (readTargetErr, targeBuffer) {
+                if (readTargetErr) return cleanup(err)
 
-                var atomicTargetMD5 = md5(buf)
+                var targetMD5 = md5(targeBuffer)
 
-                if (atomicTmpMD5 === atomicTargetMD5) {
-                 // a little janky, call end() directly
+                if (tmpMD5 === targetMD5) {
+                  // a little janky, call end() directly
                   return end()
                 }
 

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (/^win/).test(process.platform);
+  this.__isWin = (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)
@@ -92,7 +92,7 @@ function handleClose (writeStream) {
       writeStream.emit('close')
     })
   }
-  function trapWindowsEPERMRename(err) {
+  function trapWindowsEPERMRename (err) {
     if (err.syscall && err.syscall === 'rename' &&
         err.code && err.code === 'EPERM' &&
         writeStream.__isWin
@@ -101,11 +101,11 @@ function handleClose (writeStream) {
       // if the target file exists, we can ignore the EPERM error
       if (fs.existsSync(writeStream.__atomicTarget)) {
         // a little janky, call end() directly
-        return end();
+        return end()
       }
     }
 
-    cleanup(err);
+    cleanup(err)
   }
   function moveIntoPlace () {
     fs.rename(writeStream.__atomicTmp, writeStream.__atomicTarget, iferr(trapWindowsEPERMRename, end))

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function WriteStreamAtomic (path, options) {
   }
   Writable.call(this, options)
 
-  this.__isWin = (options && options.isWin) || (/^win/).test(process.platform)
+  this.__isWin = options && options.hasOwnProperty('isWin') ? options.isWin : (/^win/).test(process.platform)
 
   this.__atomicTarget = path
   this.__atomicTmp = getTmpname(path)

--- a/package.json
+++ b/package.json
@@ -10,8 +10,7 @@
     "graceful-fs": "^4.1.2",
     "iferr": "^0.1.5",
     "imurmurhash": "^0.1.4",
-    "readable-stream": "1 || 2",
-    "md5": "^2.1.0"
+    "readable-stream": "1 || 2"
   },
   "devDependencies": {
     "rimraf": "^2.4.4",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "graceful-fs": "^4.1.2",
     "iferr": "^0.1.5",
     "imurmurhash": "^0.1.4",
-    "readable-stream": "1 || 2"
+    "readable-stream": "1 || 2",
+    "md5": "^2.1.0"
   },
   "devDependencies": {
     "rimraf": "^2.4.4",

--- a/test/rename-eperm.js
+++ b/test/rename-eperm.js
@@ -5,9 +5,11 @@ var test = require('tap').test
 var rimraf = require('rimraf')
 var writeStream = require('../index.js')
 
-var target = path.resolve(__dirname, 'test-rename-eperm')
+var target = path.resolve(__dirname, 'test-rename-eperm1')
+var target2 = path.resolve(__dirname, 'test-rename-eperm2')
+var target3 = path.resolve(__dirname, 'test-rename-eperm3')
 
-test('rename eperm', function (t) {
+test('rename eperm none existing file', function (t) {
   t.plan(2)
 
   var _rename = fs.rename
@@ -17,7 +19,7 @@ test('rename eperm', function (t) {
   fs.rename = function (src, dest, cb) {
     // simulate a failure during rename where the file
     // is renamed successfully but the process encounters
-    // an EPERM error
+    // an EPERM error and the target file does not exist
     _rename(src, dest, function (e) {
       var err = new Error('TEST BREAK')
       err.syscall = 'rename'
@@ -37,6 +39,107 @@ test('rename eperm', function (t) {
     calledFinish = true
   })
   stream.on('close', function () {
+    t.is(hadError, true, 'error was caught')
+    t.is(calledFinish, false, 'finish was called before close')
+  })
+  stream.end()
+})
+
+// test existing file with diff. content
+test('rename eperm existing file different content', function (t) {
+  t.plan(2)
+
+  var _rename = fs.rename
+  fs.existsSync = function (src) {
+    return true
+  }
+  fs.rename = function (src, dest, cb) {
+    // simulate a failure during rename where the file
+    // is renamed successfully but the process encounters
+    // an EPERM error and the target file that has another content than the
+    // destination
+    _rename(src, dest, function (e) {
+      fs.writeFile(src, 'dest', function (writeErr) {
+        if (writeErr) {
+          return console.log('WRITEERR: ' + writeErr)
+        }
+
+        fs.writeFile(target2, 'target', function (writeErr) {
+          if (writeErr) {
+            return console.log('WRITEERR: ' + writeErr)
+          }
+
+          var err = new Error('TEST BREAK')
+          err.syscall = 'rename'
+          err.code = 'EPERM'
+          cb(err)
+        })
+      })
+    })
+  }
+
+  var stream = writeStream(target2, { isWin: true })
+  var hadError = false
+  var calledFinish = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.log('#', er)
+  })
+  stream.on('finish', function () {
+    calledFinish = true
+  })
+  stream.on('close', function () {
+    t.is(hadError, true, 'error was caught')
+    t.is(calledFinish, false, 'finish was called before close')
+  })
+  stream.end()
+})
+
+// test existing file with the same content
+// test existing file with diff. content
+test('rename eperm existing file different content', function (t) {
+  t.plan(2)
+
+  var _rename = fs.rename
+  fs.existsSync = function (src) {
+    return true
+  }
+  fs.rename = function (src, dest, cb) {
+    // simulate a failure during rename where the file
+    // is renamed successfully but the process encounters
+    // an EPERM error and the target file that has the same content than the
+    // destination
+    _rename(src, dest, function (e) {
+      fs.writeFile(src, 'target2', function (writeErr) {
+        if (writeErr) {
+          return console.log('WRITEERR: ' + writeErr)
+        }
+
+        fs.writeFile(target3, 'target2', function (writeErr) {
+          if (writeErr) {
+            return console.log('WRITEERR: ' + writeErr)
+          }
+
+          var err = new Error('TEST BREAK')
+          err.syscall = 'rename'
+          err.code = 'EPERM'
+          cb(err)
+        })
+      })
+    })
+  }
+
+  var stream = writeStream(target3, { isWin: true })
+  var hadError = false
+  var calledFinish = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.log('#', er)
+  })
+  stream.on('finish', function () {
+    calledFinish = true
+  })
+  stream.on('close', function () {
     t.is(hadError, false, 'error was caught')
     t.is(calledFinish, true, 'finish was called before close')
   })
@@ -45,5 +148,7 @@ test('rename eperm', function (t) {
 
 test('cleanup', function (t) {
   rimraf.sync(target)
+  rimraf.sync(target2)
+  rimraf.sync(target3)
   t.end()
 })

--- a/test/rename-eperm.js
+++ b/test/rename-eperm.js
@@ -1,0 +1,49 @@
+'use strict'
+var fs = require('graceful-fs')
+var path = require('path')
+var test = require('tap').test
+var rimraf = require('rimraf')
+var writeStream = require('../index.js')
+
+var target = path.resolve(__dirname, 'test-rename-eperm')
+
+test('rename eperm', function (t) {
+  t.plan(2)
+
+  var _rename = fs.rename
+  fs.existsSync = function (src) {
+    return true
+  }
+  fs.rename = function (src, dest, cb) {
+    // simulate a failure during rename where the file
+    // is renamed successfully but the process encounters
+    // an EPERM error
+    _rename(src, dest, function (e) {
+      var err = new Error('TEST BREAK')
+      err.syscall = 'rename'
+      err.code = 'EPERM'
+      cb(err)
+    })
+  }
+
+  var stream = writeStream(target, { isWin: true })
+  var hadError = false
+  var calledFinish = false
+  stream.on('error', function (er) {
+    hadError = true
+    console.log('#', er)
+  })
+  stream.on('finish', function () {
+    calledFinish = true
+  })
+  stream.on('close', function () {
+    t.is(hadError, false, 'error was caught')
+    t.is(calledFinish, true, 'finish was called before close')
+  })
+  stream.end()
+})
+
+test('cleanup', function (t) {
+  rimraf.sync(target)
+  t.end()
+})


### PR DESCRIPTION
**This is a fork based on the work of @codeimpossible as the base of PR #13 and with the comments as given by @iarna on that same PR.**

I've implemented a MD5 hash check to verify that the destination file is indeed the same file as the tmp file on Windows when the EPERM error is occurring.

Please note that this is my first PR on a project of this type, please let me know ~~if~~ that I did anything wrong or ~~if~~ that I need to improve on some level.
