### PR TITLE
Incorporate worker thread id in temporary filename

### DIFF
--- a/fixtures/thread-id-test-worker.js
+++ b/fixtures/thread-id-test-worker.js
@@ -1,0 +1,3 @@
+'use strict'
+
+require('worker_threads').parentPort.postMessage(require('../thread-id'))

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ var util = require('util')
 var MurmurHash3 = require('imurmurhash')
 var iferr = require('iferr')
 var crypto = require('crypto')
+var threadId = require('./thread-id')
 
 function murmurhex () {
   var hash = MurmurHash3('')
@@ -15,7 +16,7 @@ function murmurhex () {
 
 var invocations = 0
 function getTmpname (filename) {
-  return filename + '.' + murmurhex(__filename, process.pid, ++invocations)
+  return filename + '.' + murmurhex(__filename, process.pid, threadId, ++invocations)
 }
 
 var setImmediate = global.setImmediate || setTimeout

--- a/test/thread-id.js
+++ b/test/thread-id.js
@@ -1,0 +1,30 @@
+'use strict'
+
+var test = require('tap').test
+var path = require('path')
+var threadId = require('../thread-id')
+
+var Worker
+try {
+  Worker = require('worker_threads').Worker
+} catch (e) {}
+
+test('the main process has thread -1', function (t) {
+  t.equal(threadId, -1)
+  t.end()
+})
+
+if (Worker != null) {
+  test('workers have positive integer threadIds', function (t) {
+    t.plan(2)
+
+    var w1 = new Worker(path.join(__dirname, '../fixtures/thread-id-test-worker.js'))
+    w1.once('message', function (message) {
+      t.equal(message, 1)
+    })
+    var w2 = new Worker(path.join(__dirname, '../fixtures/thread-id-test-worker.js'))
+    w2.once('message', function (message) {
+      t.equal(message, 2)
+    })
+  })
+}

--- a/thread-id.js
+++ b/thread-id.js
@@ -1,0 +1,16 @@
+'use strict'
+
+var threadId
+try {
+  var Worker = require('worker_threads')
+  if (Worker.isMainThread) {
+    threadId = -1
+  } else {
+    threadId = Worker.threadId
+  }
+} catch (e) {
+  // no worker support
+  threadId = -1
+}
+
+module.exports = threadId


### PR DESCRIPTION
# What / Why
With the addition of Worker Threads [0] in Node, multiple concurrent threads could attempt to write to the same temporary filename, given they share the same `process.pid`, and could share the same invocation count as well. This incorporates the thread id, exposed from the `worker_threads` exports as `threadId`. 

The "main" process does not have a threadId, so `-1` is used as its id in that case, as well as in the case the `worker_threads` module isn't available, such as in older versions of node.

## Test Plan
Added a test for normalizing the `threadId`.

## References
[0] https://nodejs.org/api/worker_threads.html

cc @isaacs @aeschright @padmaia @devongovett @mischnic