### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: node_js
+arch:
+ - amd64
+ - ppc64le
 sudo: false
 before_install:
     - "npm -g install npm"


### PR DESCRIPTION
Hi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch.

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/fs-write-stream-atomic
Please have a look.

Thank you